### PR TITLE
feat: add generate workflow

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,32 @@
+name: Generate
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: 0 0/1 * * *
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+
+      - run: npm i -g pnpm
+
+      - run: pnpm rm mahiro && pnpm i && pnpm sync:bgm
+        working-directory: ./mahiro
+
+      - run: pnpm i && pnpm build
+        working-directory: ./render/common
+
+      - run: pnpm i && pnpm copy && pnpm start --generate
+        working-directory: ./server
+
+      - uses: actions/upload-artifact@v3.1.2
+        with:
+          name: output
+          path: ./server/output.png
+          retention-days: 1

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,4 +1,4 @@
-name: Generate
+name: Generate Image
 
 on:
   push:
@@ -11,22 +11,53 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-      - run: npm i -g pnpm
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: pnpm
 
-      - run: pnpm rm mahiro && pnpm i && pnpm sync:bgm
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install deps
+        run: pnpm i
+
+      - name: Prepare Bgm Data
+        run: pnpm sync:bgm
         working-directory: ./mahiro
 
-      - run: pnpm i && pnpm build
+      - name: Prepare HTML
+        run: pnpm build
         working-directory: ./render/common
 
-      - run: pnpm i && pnpm copy && pnpm start --generate
+      - name: Generate Image
+        run: pnpm copy && pnpm start --generate --compress
         working-directory: ./server
 
-      - uses: actions/upload-artifact@v3.1.2
+      - name: Check file existence
+        id: check_files
+        uses: andstor/file-existence-action@v2
         with:
-          name: output
-          path: ./server/output.png
-          retention-days: 1
+          files: "server/output.png"
+
+      - name: Move Image
+        if: steps.check_files.outputs.files_exists == 'true'
+        run: |
+          mkdir -p output
+          mv server/output.png output/output.png
+
+      - name: Deploy
+        if: steps.check_files.outputs.files_exists == 'true'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: output
+          publish_dir: ./output

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
 
   server:
     dependencies:
+      '@napi-rs/image':
+        specifier: ^1.6.1
+        version: 1.6.1
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12
@@ -202,7 +205,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/compat-data': 7.22.9
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-validator-option': 7.22.5
       browserslist: 4.21.9
       lru-cache: 5.1.1
@@ -231,7 +234,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
@@ -241,7 +244,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
       debug: 4.3.4
@@ -285,7 +288,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-simple-access': 7.22.5
@@ -308,7 +311,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-wrap-function': 7.22.9
@@ -319,7 +322,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -402,7 +405,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.22.9):
@@ -411,7 +414,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-transform-optional-chaining': 7.22.6(@babel/core@7.22.9)
@@ -457,7 +460,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
 
   /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.22.9):
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
@@ -465,7 +468,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -474,7 +477,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.22.9):
@@ -482,7 +485,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.22.9):
@@ -491,7 +494,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.22.9):
@@ -499,7 +502,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.22.9):
@@ -507,7 +510,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.22.9):
@@ -516,7 +519,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-import-attributes@7.22.5(@babel/core@7.22.9):
@@ -525,7 +528,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.22.9):
@@ -533,7 +536,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.22.9):
@@ -541,7 +544,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.22.9):
@@ -550,7 +553,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.22.9):
@@ -558,7 +561,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.22.9):
@@ -566,7 +569,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.22.9):
@@ -574,7 +577,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.22.9):
@@ -582,7 +585,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.22.9):
@@ -590,7 +593,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.22.9):
@@ -598,7 +601,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.22.9):
@@ -607,7 +610,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.22.9):
@@ -616,7 +619,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.22.9):
@@ -625,7 +628,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.22.9):
@@ -634,7 +637,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -644,7 +647,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-async-generator-functions@7.22.7(@babel/core@7.22.9):
@@ -653,7 +656,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.22.9)
@@ -665,7 +668,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.22.9)
@@ -676,7 +679,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-block-scoping@7.22.5(@babel/core@7.22.9):
@@ -685,7 +688,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.22.9):
@@ -694,7 +697,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -704,7 +707,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.22.9)
@@ -715,7 +718,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-environment-visitor': 7.22.5
@@ -732,7 +735,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/template': 7.22.5
 
@@ -742,7 +745,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.22.9):
@@ -751,7 +754,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -761,7 +764,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-dynamic-import@7.22.5(@babel/core@7.22.9):
@@ -770,7 +773,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.9)
 
@@ -780,7 +783,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -790,7 +793,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.9)
 
@@ -800,7 +803,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.22.9):
@@ -809,7 +812,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
@@ -820,7 +823,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.22.9)
 
@@ -830,7 +833,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-logical-assignment-operators@7.22.5(@babel/core@7.22.9):
@@ -839,7 +842,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.9)
 
@@ -849,7 +852,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.22.9):
@@ -858,7 +861,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -868,7 +871,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
@@ -879,7 +882,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
@@ -891,7 +894,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -901,7 +904,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -911,7 +914,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-nullish-coalescing-operator@7.22.5(@babel/core@7.22.9):
@@ -920,7 +923,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.9)
 
@@ -930,7 +933,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.9)
 
@@ -941,7 +944,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.22.9
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.9)
@@ -953,7 +956,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-replace-supers': 7.22.9(@babel/core@7.22.9)
 
@@ -963,7 +966,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.22.9)
 
@@ -973,7 +976,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.9)
@@ -984,7 +987,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.22.9):
@@ -993,7 +996,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -1003,7 +1006,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
@@ -1015,7 +1018,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-react-display-name@7.22.5(@babel/core@7.22.9):
@@ -1024,7 +1027,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.22.9):
@@ -1033,7 +1036,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.22.9)
 
   /@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.22.9):
@@ -1042,7 +1045,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
@@ -1055,7 +1058,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -1065,7 +1068,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.1
 
@@ -1075,7 +1078,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.22.9):
@@ -1084,7 +1087,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-spread@7.22.5(@babel/core@7.22.9):
@@ -1093,7 +1096,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
@@ -1103,7 +1106,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.22.9):
@@ -1112,7 +1115,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.22.9):
@@ -1121,7 +1124,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-typescript@7.22.9(@babel/core@7.22.9):
@@ -1130,7 +1133,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
@@ -1142,7 +1145,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-unicode-property-regex@7.22.5(@babel/core@7.22.9):
@@ -1151,7 +1154,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -1161,7 +1164,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -1171,7 +1174,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.22.9)
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -1270,7 +1273,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.22.9)
       '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.22.9)
@@ -1840,6 +1843,136 @@ packages:
       - supports-color
     dev: true
 
+  /@napi-rs/image-android-arm-eabi@1.6.1:
+    resolution: {integrity: sha512-06GgTsnTzd+LQbj1EVciU4kOP7dUL40y3+vZkMe5yYNNdL8F199tnDxGodL8UYjHKrz+shKdZxjzq3ppE12dNg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/image-android-arm64@1.6.1:
+    resolution: {integrity: sha512-RjjupJNodv1beIHEIk6CPwzzQHexy9G1KT/xce3PDV+r2RwOaZ5uisAoZeUQMpJ7U9yM8qEqBYJ0ZJRxOL3IyA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/image-darwin-arm64@1.6.1:
+    resolution: {integrity: sha512-7SDYifSZPDa1TnDAxh641Qp8bB6XwLRMzboqlib9VVfW4B+xG8USTFX+pyc7AGA6Qt9YDx0fCTstGTdQZ4x0Vg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/image-darwin-x64@1.6.1:
+    resolution: {integrity: sha512-JESPPgW1IVKyMk/jzLmbbE/WcJ9GliUljWNpTaZftTISPibQ0kXLFWITTpvKKGXOi1wqHw2HNo+xPwaBViRYPQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/image-freebsd-x64@1.6.1:
+    resolution: {integrity: sha512-uHe50MR6fHROzrOVv2lKowo0fnm51rZFQUgjBrb4U7sRof5MH6yXkiikd0zEVbqbK16JybCJhx8JMxg1fStOSw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/image-linux-arm-gnueabihf@1.6.1:
+    resolution: {integrity: sha512-MioNufx/KaMg4ksisp2/5fwnKj+Le0jF9DKgdckVKd/OnHASTATYQN4akXXejMgcDdKyiInGtmcHK1N4Z29HKQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/image-linux-arm64-gnu@1.6.1:
+    resolution: {integrity: sha512-TIq7dgKs15r1JdBxJYKf6YVAydtsoOEdBvfWITd8zIN1VAM3J0B5/efCDf9TWOSeh5j6Do2HrgzUWa0SF8wakA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/image-linux-arm64-musl@1.6.1:
+    resolution: {integrity: sha512-vSF6bNrWbKADS4lnapX7dwYwLCduG2HMhDzLx/q8a7eDVDfqXCvAhRTcvOeNkQRQ7vmzyYpu3qsjI36IK7Y60w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/image-linux-x64-gnu@1.6.1:
+    resolution: {integrity: sha512-a0ChzvNRF4uwSGCnBuLDFTGrBHlaltEeRsd1kU4c7+d27qs7LFi89oDrVXItM/t+OVD4svPx4zyUQXtHHuVU7w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/image-linux-x64-musl@1.6.1:
+    resolution: {integrity: sha512-4mZ0pGP3tFidnKqVhbon48jX0+BddAE2ZiEtfXNypOx25pizVec1sSgHACKgFV9Yn0bVEGZozjxYeoERCUkdyA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/image-win32-ia32-msvc@1.6.1:
+    resolution: {integrity: sha512-0XNbGAv17xYfo2mrS8jSVpJN8nJrdqimr/1aUojPO9HdYIdKYBNWz1o5qulolaPJqa+T72yEevnuhkgmLxJLsA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/image-win32-x64-msvc@1.6.1:
+    resolution: {integrity: sha512-hvQT+YID51JSxr9HbxmhKa8Y4jZh+4nxJZ33H0NhT/xFd6bGa4+EcIjMNqixKU8PmO9BYjEVH8FWHev6AEvp4A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/image@1.6.1:
+    resolution: {integrity: sha512-idrYU7POm9T7dcZVkWN8kpFYNIj0XaT20LtTzwWGZsR5Dhsce0hxwVGnKg2Kq/Z/AhHkR6MDagkOX5qTl5LjoQ==}
+    engines: {node: '>= 10'}
+    optionalDependencies:
+      '@napi-rs/image-android-arm-eabi': 1.6.1
+      '@napi-rs/image-android-arm64': 1.6.1
+      '@napi-rs/image-darwin-arm64': 1.6.1
+      '@napi-rs/image-darwin-x64': 1.6.1
+      '@napi-rs/image-freebsd-x64': 1.6.1
+      '@napi-rs/image-linux-arm-gnueabihf': 1.6.1
+      '@napi-rs/image-linux-arm64-gnu': 1.6.1
+      '@napi-rs/image-linux-arm64-musl': 1.6.1
+      '@napi-rs/image-linux-x64-gnu': 1.6.1
+      '@napi-rs/image-linux-x64-musl': 1.6.1
+      '@napi-rs/image-win32-ia32-msvc': 1.6.1
+      '@napi-rs/image-win32-x64-msvc': 1.6.1
+    dev: false
+
   /@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3:
     resolution: {integrity: sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==}
     requiresBuild: true
@@ -2290,7 +2423,7 @@ packages:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
       '@babel/compat-data': 7.22.9
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.9)
       semver: 6.3.1
     transitivePeerDependencies:
@@ -2301,7 +2434,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.9)
       core-js-compat: 3.31.1
     transitivePeerDependencies:
@@ -2312,7 +2445,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.22.9
+      '@babel/core': registry.npmjs.org/@babel/core@7.22.9
       '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.9)
     transitivePeerDependencies:
       - supports-color
@@ -5810,7 +5943,6 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   registry.npmjs.org/@babel/plugin-transform-react-constant-elements@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-BF5SXoO+nX3h5OhlN78XbbDrBOffv+AxPP2ENaJOVqjWCgBDeOY3WcaUcddutGSfoap+5NEQ/q/4I3WZIvgkXA==, registry: https://registry.npmmirror.com/, tarball: https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.22.5.tgz}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,9 +1,10 @@
 import express from 'express'
-import { existsSync, readFileSync, statSync } from 'fs'
+import { existsSync, readFileSync, statSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import dayjs from 'dayjs'
 import { getAllData } from './data'
 import nodeHtmlToImage from 'node-html-to-image'
+import { pngQuantize } from '@napi-rs/image'
 
 const htmlPath = join(__dirname, './index.html')
 const outputPath = join(__dirname, './output.png')
@@ -19,8 +20,24 @@ const bangumi = JSON.parse(readFileSync(bangumiPath, 'utf-8')) as Record<
   any
 >
 
+let isRunning = false
+
 const run = async () => {
-  const render = async (day: string) => {
+  const compress = async () => {
+    if (!existsSync(outputPath)) {
+      console.error(`${pluginName}: compress failed, file not found`)
+      return
+    }
+    console.log(`${pluginName}: trigger compress`)
+    const fileBuffer = readFileSync(outputPath)
+    const compressedBuffer = await pngQuantize(fileBuffer, {
+      maxQuality: 80,
+    })
+    console.log(`${pluginName}: trigger compress success`)
+    console.log(`${pluginName}: write file`)
+    writeFileSync(outputPath, compressedBuffer)
+  }
+  const render = async (day: string, needCompress = false) => {
     // if create time is today, use cache
     if (existsSync(outputPath)) {
       const stats = statSync(outputPath)
@@ -33,6 +50,11 @@ const run = async () => {
       }
     }
 
+    // TODO: pm2
+    if (isRunning) {
+      return
+    }
+    isRunning = true
     console.log(`${pluginName}: get all remote data`)
     const remoteData = await getAllData()
     console.log(`${pluginName}: get all remote data success`)
@@ -67,12 +89,31 @@ const run = async () => {
       },
     })
     console.log(`${pluginName}: render over for ${day}`)
+    isRunning = false
+
+    if (needCompress) {
+      await compress()
+    }
     return buffer
   }
 
-  if (process.argv.includes('--generate')){
-    const mark = dayjs().format('ddd').toLowerCase()
-    await render(mark)
+  const getDayMark = () => {
+    return dayjs().format('ddd').toLowerCase()
+  }
+  const useGenerate = process.argv.includes('--generate')
+  if (useGenerate){
+    const useCompress = process.argv.includes('--compress')
+    console.log(`${pluginName}: generate mode`)
+    const mark = getDayMark()
+    try {
+      console.log(`${pluginName}: trigger render`)
+      await render(mark, useCompress)
+      console.log(`${pluginName}: render success for ${mark}`)
+    } catch (e) {
+      console.error(`${pluginName}: render failed for ${mark}`)
+      console.error(e)
+      return
+    }
     return
   }
 
@@ -80,8 +121,9 @@ const run = async () => {
   app.get(`/api/v1/dayNews`, async (req, res) => {
     try {
       console.log(`${pluginName}: trigger render`)
-      const mark = dayjs().format('ddd').toLowerCase()
-      const buffer = await render(mark)
+      const mark = getDayMark()
+      const useCompress = !!req.query?.compress?.length
+      const buffer = await render(mark, useCompress)
       if (!buffer || !existsSync(outputPath)) {
         console.error(`${pluginName}: render failed for ${mark}`)
         throw new Error('render failed')

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,7 +20,6 @@ const bangumi = JSON.parse(readFileSync(bangumiPath, 'utf-8')) as Record<
 >
 
 const run = async () => {
-  const app = express()
   const render = async (day: string) => {
     // if create time is today, use cache
     if (existsSync(outputPath)) {
@@ -70,6 +69,14 @@ const run = async () => {
     console.log(`${pluginName}: render over for ${day}`)
     return buffer
   }
+
+  if (process.argv.includes('--generate')){
+    const mark = dayjs().format('ddd').toLowerCase()
+    await render(mark)
+    return
+  }
+
+  const app = express()
   app.get(`/api/v1/dayNews`, async (req, res) => {
     try {
       console.log(`${pluginName}: trigger render`)

--- a/server/package.json
+++ b/server/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "@napi-rs/image": "^1.6.1",
     "cheerio": "1.0.0-rc.12",
     "dayjs": "^1.11.9",
     "express": "^4.18.2",


### PR DESCRIPTION
用Github Action生成日报图

待定：
现在是存到Action的Artifact，要用的话得调用接口下载下来然后解压出图片，等于只省去了渲染的环境。
要不弄成直接push到仓库里？不过这样的话仓库就每天都一堆自动的commit。看能不能接受。